### PR TITLE
constants.py and spec atom error handling

### DIFF
--- a/dbstep/Dbstep.py
+++ b/dbstep/Dbstep.py
@@ -20,34 +20,7 @@ import numpy as np
 from optparse import OptionParser
 
 from dbstep import sterics, parse_data, calculator, writer
-
-#Chemistry Arrays
-
-#Bondi Van der Waals radii taken from [J. Phys. Chem. 1964, 68, 441] & [J. Phys. Chem. A. 2009, 103, 5806-5812]
-# All other elements set to 2.0A - common in other chemistry programs
-bondi = {"Bq": 0.00, "H": 1.09,"He": 1.40,
-	"Li":1.81,"Be":1.53,"B":1.92,"C":1.70,"N":1.55,"O":1.52,"F":1.47,"Ne":1.54,
-	"Na":2.27,"Mg":1.73,"Al":1.84,"Si":2.10,"P":1.80,"S":1.80,"Cl":1.75,"Ar":1.88,
-	"K":2.75,"Ca":2.31,"Ni": 1.63,"Cu":1.40,"Zn":1.39,"Ga":1.87,"Ge":2.11,"As":1.85,"Se":1.90,"Br":1.83,"Kr":2.02,
-	"Rb":3.03,"Sr":2.49,"Pd": 1.63,"Ag":1.72,"Cd":1.58,"In":1.93,"Sn":2.17,"Sb":2.06,"Te":2.06,"I":1.98,"Xe":2.16,
-	"Cs":3.43,"Ba":2.68,"Pt":1.72,"Au":1.66,"Hg":1.55,"Tl":1.96,"Pb":2.02,"Bi":2.07,"Po":1.97,"At":2.02,"Rn":2.20,
-	"Fr":3.48,"Ra":2.83, "U":1.86 }
-
-periodictable = ["","H","He","Li","Be","B","C","N","O","F","Ne",
-	"Na","Mg","Al","Si","P","S","Cl","Ar",
-	"K","Ca","Sc","Ti","V","Cr","Mn","Fe","Co","Ni","Cu","Zn","Ga","Ge","As","Se","Br","Kr",
-	"Rb","Sr","Y","Zr","Nb","Mo","Tc","Ru","Rh","Pd","Ag","Cd","In","Sn","Sb","Te","I","Xe",
-	"Cs","Ba","La","Ce","Pr","Nd","Pm","Sm","Eu","Gd","Tb","Dy","Ho","Er","Tm","Yb","Lu","Hf","Ta","W","Re","Os","Ir","Pt","Au","Hg","Tl","Pb","Bi","Po","At","Rn",
-	"Fr","Ra","Ac","Th","Pa","U","Np","Pu","Am","Cm","Bk","Cf","Es","Fm","Md","No","Lr","Rf","Db","Sg","Bh","Hs","Mt","Ds","Rg","Cn","Nh","Fl","Mc","Lv","Ts","Og"]
-
-metals = ["Li","Be","Na","Mg","Al","K","Ca","Sc","Ti","V","Cr","Mn","Fe","Co","Ni","Cu","Zn","Ga","Rb","Sr","Y","Zr","Nb","Mo",
-	"Tc","Ru","Rh","Pd","Ag","Cd","In","Sn","Cs","Ba","La","Ce","Pr","Nd","Pm","Sm","Eu","Gd","Tb","Dy","Ho","Er","Tm","Yb","Lu",
-	"Hf","Ta","W","Re","Os","Ir","Pt","Au","Hg","Tl","Pb","Bi","Po","Fr","Ra","Ac","Th","Pa","U","Np","Pu","Am","Cm","Bk","Cf",
-	"Es","Fm","Md","No","Lr","Rf","Db","Sg","Bh","Hs","Mt","Ds","Rg","Cn","Uut","Fl","Uup","Lv"]
-
-isovals = {"Bq": 0.00, "H": .00475}
-BOHR_TO_ANG = 0.529177249
-
+from dbstep.constants import periodic_table, bondi, metals
 
 class dbstep:
 	"""
@@ -179,7 +152,7 @@ class dbstep:
 			except:
 				mol.RADII = []
 				for atom in mol.ATOMTYPES:
-					if atom not in periodictable:
+					if atom not in periodic_table:
 						print("\n   UNABLE TO GENERATE VDW RADII FOR ATOM: ", atom); exit()
 					elif atom not in bondi:
 						mol.RADII.append(2.0)

--- a/dbstep/Dbstep.py
+++ b/dbstep/Dbstep.py
@@ -69,41 +69,10 @@ class dbstep:
 			ext = 'rdkit'
 			
 		r_intervals, origin = 1, np.array([0,0,0])
-		
-		# if atoms are not specified upon input, grab first and second atom in file
-		# allow for multiple ways to specify atoms (H1 or just 1)
-		if options.spec_atom_1 == False:
-			options.spec_atom_1 = 1
-		else: 
-			try: 
-				options.spec_atom_1 = int(options.spec_atom_1) 
-			except:
-				options.spec_atom_1 = int(''.join([s for s in options.spec_atom_1 if s.isdigit()]))
-		#set default for atom 2
-		if options.spec_atom_2 == False:
-			options.spec_atom_2 = [2]
-		else:
-			try:
-				#check if int was supplied
-				options.spec_atom_2 = [int(options.spec_atom_2)]
-			except: 
-				#check for multiple atoms supplied
-				if ',' in options.spec_atom_2:
-					try: 
-						#list of ints supplied
-						options.spec_atom_2 = [int(s) for s in options.spec_atom_2.split(',') if s.isdigit()]
-					except: 
-						#atoms and atom types supplied
-						atom2_id = []
-						for i in options.spec_atom_2.split(','):
-							atom2_id.append([int(x) for x in s if x.isdigit()][0])
-				elif isinstance(options.spec_atom_2,list):
-					pass
-				else:
-					#single atom and atom type supplied
-					options.spec_atom_2 = [int(''.join([s for s in options.spec_atom_2 if s.isdigit()]))]
-			 
-		#Parse coordinate/volumetric information
+
+		self._get_spec_atoms(options)
+
+		# Parse coordinate/volumetric information
 		if ext == '.cube':
 			options.surface = 'density'
 			mol = parse_data.GetCubeData(name)
@@ -418,6 +387,37 @@ class dbstep:
 		if options.commandline == False and ext != 'rdkit':
 			writer.xyz_export(file,mol)
 			writer.pymol_export(file, mol, spheres, cylinders, options.isoval, options.visv, options.viss)
+
+	def _get_spec_atoms(self, options):
+		# if atoms are not specified upon input, grab first and second atom in file
+		# allow for multiple ways to specify atoms (H1 or just 1)
+		if not options.spec_atom_1:
+			options.spec_atom_1 = 1
+		else:
+			try:
+				options.spec_atom_1 = int(options.spec_atom_1)
+			except ValueError:
+				sys.exit(f'{options.spec_atom_1} is not a valid input for atom1. Please enter an integer index.')
+		# set default for atom 2
+		if not options.spec_atom_2:
+			options.spec_atom_2 = [2]
+		else:
+			try:
+				# check if int was supplied
+				options.spec_atom_2 = [int(options.spec_atom_2)]
+			except ValueError:
+				# check for multiple atoms supplied
+				if ',' in options.spec_atom_2:
+					# list of ints supplied
+					options.spec_atom_2 = [
+						int(s) if s.isdigit()
+						else sys.exit(f'{s} is not a valid input for atom2. Please enter an integer index.')
+						for s in options.spec_atom_2.split(',')]
+				else:
+					sys.exit(
+						f'{options.spec_atom_2} is not a valid input for atom2. Valid inputs are: \n'
+						f'\tAn int, comma separated ints, or a python list of ints')
+
 
 class options_add:
         pass

--- a/dbstep/Dbstep.py
+++ b/dbstep/Dbstep.py
@@ -413,6 +413,8 @@ class dbstep:
 						int(s) if s.isdigit()
 						else sys.exit(f'{s} is not a valid input for atom2. Please enter an integer index.')
 						for s in options.spec_atom_2.split(',')]
+				elif isinstance(options.spec_atom_2, list):
+					pass
 				else:
 					sys.exit(
 						f'{options.spec_atom_2} is not a valid input for atom2. Valid inputs are: \n'

--- a/dbstep/__init__.py
+++ b/dbstep/__init__.py
@@ -3,3 +3,4 @@ from dbstep import calculator
 from dbstep import sterics
 from dbstep import parse_data
 from dbstep import writer
+from dbstep import constants

--- a/dbstep/calculator.py
+++ b/dbstep/calculator.py
@@ -2,6 +2,7 @@
 import math
 import numpy as np
 import sys
+from dbstep.constants import metals
 
 
 """
@@ -9,13 +10,6 @@ calculator
 
 Performs calculations for finding angles, translation and rotation of molecules
 """
-
-
-metals = ["Li","Be","Na","Mg","Al","K","Ca","Sc","Ti","V","Cr","Mn","Fe","Co","Ni","Cu","Zn","Ga","Rb","Sr","Y","Zr","Nb","Mo",
-	"Tc","Ru","Rh","Pd","Ag","Cd","In","Sn","Cs","Ba","La","Ce","Pr","Nd","Pm","Sm","Eu","Gd","Tb","Dy","Ho","Er","Tm","Yb","Lu",
-	"Hf","Ta","W","Re","Os","Ir","Pt","Au","Hg","Tl","Pb","Bi","Po","Fr","Ra","Ac","Th","Pa","U","Np","Pu","Am","Cm","Bk","Cf",
-	"Es","Fm","Md","No","Lr","Rf","Db","Sg","Bh","Hs","Mt","Ds","Rg","Cn","Uut","Fl","Uup","Lv"]
-	
 	
 def angle_between(v1, v2):
 	""" Returns the angle in radians between vectors 'v1' and 'v2' """

--- a/dbstep/constants.py
+++ b/dbstep/constants.py
@@ -1,0 +1,38 @@
+# -*- coding: UTF-8 -*-
+
+"""
+constants
+
+Constant objects used throughout the project.
+
+"""
+
+# Chemistry Arrays
+
+# Bondi Van der Waals radii taken from [J. Phys. Chem. 1964, 68, 441] & [J. Phys. Chem. A. 2009, 103, 5806-5812]
+# All other elements set to 2.0A - common in other chemistry programs
+bondi = {"Bq": 0.00, "H": 1.09,"He": 1.40,
+	"Li":1.81,"Be":1.53,"B":1.92,"C":1.70,"N":1.55,"O":1.52,"F":1.47,"Ne":1.54,
+	"Na":2.27,"Mg":1.73,"Al":1.84,"Si":2.10,"P":1.80,"S":1.80,"Cl":1.75,"Ar":1.88,
+	"K":2.75,"Ca":2.31,"Ni": 1.63,"Cu":1.40,"Zn":1.39,"Ga":1.87,"Ge":2.11,"As":1.85,"Se":1.90,"Br":1.83,"Kr":2.02,
+	"Rb":3.03,"Sr":2.49,"Pd": 1.63,"Ag":1.72,"Cd":1.58,"In":1.93,"Sn":2.17,"Sb":2.06,"Te":2.06,"I":1.98,"Xe":2.16,
+	"Cs":3.43,"Ba":2.68,"Pt":1.72,"Au":1.66,"Hg":1.55,"Tl":1.96,"Pb":2.02,"Bi":2.07,"Po":1.97,"At":2.02,"Rn":2.20,
+	"Fr":3.48,"Ra":2.83, "U":1.86 }
+
+periodic_table = ["","H","He","Li","Be","B","C","N","O","F","Ne",
+	"Na","Mg","Al","Si","P","S","Cl","Ar",
+	"K","Ca","Sc","Ti","V","Cr","Mn","Fe","Co","Ni","Cu","Zn","Ga","Ge","As","Se","Br","Kr",
+	"Rb","Sr","Y","Zr","Nb","Mo","Tc","Ru","Rh","Pd","Ag","Cd","In","Sn","Sb","Te","I","Xe",
+	"Cs","Ba","La","Ce","Pr","Nd","Pm","Sm","Eu","Gd","Tb","Dy","Ho","Er","Tm","Yb","Lu","Hf","Ta","W","Re","Os","Ir","Pt","Au","Hg","Tl","Pb","Bi","Po","At","Rn",
+	"Fr","Ra","Ac","Th","Pa","U","Np","Pu","Am","Cm","Bk","Cf","Es","Fm","Md","No","Lr","Rf","Db","Sg","Bh","Hs","Mt","Ds","Rg","Cn","Nh","Fl","Mc","Lv","Ts","Og"]
+
+metals = ["Li","Be","Na","Mg","Al","K","Ca","Sc","Ti","V","Cr","Mn","Fe","Co","Ni","Cu","Zn","Ga","Rb","Sr","Y","Zr","Nb","Mo",
+	"Tc","Ru","Rh","Pd","Ag","Cd","In","Sn","Cs","Ba","La","Ce","Pr","Nd","Pm","Sm","Eu","Gd","Tb","Dy","Ho","Er","Tm","Yb","Lu",
+	"Hf","Ta","W","Re","Os","Ir","Pt","Au","Hg","Tl","Pb","Bi","Po","Fr","Ra","Ac","Th","Pa","U","Np","Pu","Am","Cm","Bk","Cf",
+	"Es","Fm","Md","No","Lr","Rf","Db","Sg","Bh","Hs","Mt","Ds","Rg","Cn","Uut","Fl","Uup","Lv"]
+
+isovals = {"Bq": 0.00, "H": .00475}
+
+# Values
+
+BOHR_TO_ANG = 0.529177249

--- a/dbstep/parse_data.py
+++ b/dbstep/parse_data.py
@@ -2,6 +2,7 @@
 import os, sys
 import numpy as np
 import cclib
+from dbstep.constants import BOHR_TO_ANG, periodic_table
 
 
 """
@@ -14,22 +15,12 @@ Currently supporting:
 """
 
 
-BOHR_TO_ANG = 0.529177249
-
-periodictable = ["","H","He","Li","Be","B","C","N","O","F","Ne",
-	"Na","Mg","Al","Si","P","S","Cl","Ar",
-	"K","Ca","Sc","Ti","V","Cr","Mn","Fe","Co","Ni","Cu","Zn","Ga","Ge","As","Se","Br","Kr",
-	"Rb","Sr","Y","Zr","Nb","Mo","Tc","Ru","Rh","Pd","Ag","Cd","In","Sn","Sb","Te","I","Xe",
-	"Cs","Ba","La","Ce","Pr","Nd","Pm","Sm","Eu","Gd","Tb","Dy","Ho","Er","Tm","Yb","Lu","Hf","Ta","W","Re","Os","Ir","Pt","Au","Hg","Tl","Pb","Bi","Po","At","Rn",
-	"Fr","Ra","Ac","Th","Pa","U","Np","Pu","Am","Cm","Bk","Cf","Es","Fm","Md","No","Lr","Rf","Db","Sg","Bh","Hs","Mt","Ds","Rg","Cn","Nh","Fl","Mc","Lv","Ts","Og"]
-
-
 def element_id(massno, num=False):
 	"""Return element id number"""
 	try:
 		if num:
-			return periodictable.index(massno)
-		else: return periodictable[massno]
+			return periodic_table.index(massno)
+		else: return periodic_table[massno]
 	except IndexError:
 		return "XX"
 
@@ -71,7 +62,7 @@ class GetCubeData:
 					self.z_inc = [coord[1]*BOHR_TO_ANG, coord[2]*BOHR_TO_ANG,coord[3]*BOHR_TO_ANG]
 				elif len(coord) == 5:
 					if coord[0] == int(coord[0]) and isinstance(coord[2], float) and isinstance(coord[3], float) and isinstance(coord[4], float):
-						[atom, x,y,z] = [periodictable[int(coord[0])], float(coord[2])*BOHR_TO_ANG, float(coord[3])*BOHR_TO_ANG, float(coord[4])*BOHR_TO_ANG]
+						[atom, x,y,z] = [periodic_table[int(coord[0])], float(coord[2])*BOHR_TO_ANG, float(coord[3])*BOHR_TO_ANG, float(coord[4])*BOHR_TO_ANG]
 						self.ATOMNUM.append(int(coord[0]))
 						self.ATOMTYPES.append(atom)
 						self.CARTESIANS.append([x,y,z])
@@ -186,7 +177,7 @@ class GetData_cclib:
 		
 		# store cartesians and symbols
 		self.CARTESIANS = np.array(parsed.atomcoords[-1])
-		[self.ATOMTYPES.append(periodictable[i]) for i in parsed.atomnos]
+		[self.ATOMTYPES.append(periodic_table[i]) for i in parsed.atomnos]
 		self.ATOMTYPES = np.array(self.ATOMTYPES)
 		
 		# remove hydrogens if requested, update spec_atom numbering if necessary

--- a/dbstep/writer.py
+++ b/dbstep/writer.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 import os
-
+from dbstep.constants import BOHR_TO_ANG
 
 """
 writer
@@ -8,10 +8,6 @@ writer
 Contains classes and methods to write data to files
 
 """
-
-
-BOHR_TO_ANG = 0.529177249
-
 
 
 class Logger:


### PR DESCRIPTION
This PR does two things:

1. Moved global constants to their own file instead of being defined at the beginning of each module
2. Fixed error handling of spec atom input and moved the process to its own non-public method