### PR TITLE
Created an Abstract Base Class in parse_data.py

### DIFF
--- a/dbstep/Dbstep.py
+++ b/dbstep/Dbstep.py
@@ -76,7 +76,7 @@ class dbstep:
 		mol = parse_data.read_input(file, ext, options)
 		
 		if len(mol.ATOMTYPES) <= 1:
-			if mol.FORMAT == 'RDKit-':
+			if mol.FORMAT == 'RDKit':
 				sys.exit("One or zero atoms found in RDKit mol object - Please try again with a different input molecule or add 3D coordinates")
 			else:
 				sys.exit("One or zero atoms found in "+file+" - Please try again with a different input file.")

--- a/dbstep/Dbstep.py
+++ b/dbstep/Dbstep.py
@@ -79,7 +79,7 @@ class dbstep:
 		elif ext == 'rdkit':
 			mol = parse_data.GetData_RDKit(name, options.noH, options.spec_atom_1, options.spec_atom_2)
 		elif ext in [".xyz",'.com','.gjf']:
-			mol = parse_data.GetXYZData(name, ext, options.noH,options.spec_atom_1, options.spec_atom_2)
+			mol = parse_data.XYZParser(file, ext[1:], options.noH,options.spec_atom_1, options.spec_atom_2)
 			if options.noH:
 				options.spec_atom_1 = mol.spec_atom_1
 				options.spec_atom_2 = mol.spec_atom_2

--- a/dbstep/Dbstep.py
+++ b/dbstep/Dbstep.py
@@ -76,15 +76,13 @@ class dbstep:
 		if ext == '.cube':
 			options.surface = 'density'
 			mol = parse_data.CubeParser(file, "cube")
-		elif ext == 'rdkit':
-			mol = parse_data.GetData_RDKit(name, options.noH, options.spec_atom_1, options.spec_atom_2)
-		elif ext in [".xyz",'.com','.gjf']:
-			mol = parse_data.XYZParser(file, ext[1:], options.noH,options.spec_atom_1, options.spec_atom_2)
-			if options.noH:
-				options.spec_atom_1 = mol.spec_atom_1
-				options.spec_atom_2 = mol.spec_atom_2
 		else:
-			mol = parse_data.GetData_cclib(name, ext, options.noH,options.spec_atom_1, options.spec_atom_2)
+			if ext in [".xyz", '.com', '.gjf']:
+				mol = parse_data.XYZParser(file, ext[1:], options.noH, options.spec_atom_1, options.spec_atom_2)
+			elif ext == 'rdkit':
+				mol = parse_data.RDKitParser(file, options.noH, options.spec_atom_1, options.spec_atom_2)
+			else:
+				mol = parse_data.cclibParser(file, ext[1:], options.noH, options.spec_atom_1, options.spec_atom_2)
 			if options.noH:
 				options.spec_atom_1 = mol.spec_atom_1
 				options.spec_atom_2 = mol.spec_atom_2

--- a/dbstep/Dbstep.py
+++ b/dbstep/Dbstep.py
@@ -73,19 +73,7 @@ class dbstep:
 		self._get_spec_atoms(options)
 
 		# Parse coordinate/volumetric information
-		if ext == '.cube':
-			options.surface = 'density'
-			mol = parse_data.CubeParser(file, "cube")
-		else:
-			if ext in [".xyz", '.com', '.gjf']:
-				mol = parse_data.XYZParser(file, ext[1:], options.noH, options.spec_atom_1, options.spec_atom_2)
-			elif ext == 'rdkit':
-				mol = parse_data.RDKitParser(file, options.noH, options.spec_atom_1, options.spec_atom_2)
-			else:
-				mol = parse_data.cclibParser(file, ext[1:], options.noH, options.spec_atom_1, options.spec_atom_2)
-			if options.noH:
-				options.spec_atom_1 = mol.spec_atom_1
-				options.spec_atom_2 = mol.spec_atom_2
+		mol = parse_data.read_input(file, ext, options)
 		
 		if len(mol.ATOMTYPES) <= 1:
 			if mol.FORMAT == 'RDKit-':

--- a/dbstep/Dbstep.py
+++ b/dbstep/Dbstep.py
@@ -75,7 +75,7 @@ class dbstep:
 		# Parse coordinate/volumetric information
 		if ext == '.cube':
 			options.surface = 'density'
-			mol = parse_data.GetCubeData(name)
+			mol = parse_data.CubeParser(file, "cube")
 		elif ext == 'rdkit':
 			mol = parse_data.GetData_RDKit(name, options.noH, options.spec_atom_1, options.spec_atom_2)
 		elif ext in [".xyz",'.com','.gjf']:

--- a/dbstep/parse_data.py
+++ b/dbstep/parse_data.py
@@ -31,9 +31,9 @@ def read_input(molecule, ext, options):
 		options.surface = 'density'
 		mol = CubeParser(molecule, "cube")
 	else:
-		# if ext in [".xyz", '.com', '.gjf']:
-		# 	mol = XYZParser(molecule, ext[1:], options.noH, options.spec_atom_1, options.spec_atom_2)
-		if ext == 'rdkit':
+		if ext in [".xyz", '.com', '.gjf']:
+			mol = XYZParser(molecule, ext[1:], options.noH, options.spec_atom_1, options.spec_atom_2)
+		elif ext == 'rdkit':
 			mol = RDKitParser(molecule, options.noH, options.spec_atom_1, options.spec_atom_2)
 		else:
 			mol = cclibParser(molecule, ext[1:], options.noH, options.spec_atom_1, options.spec_atom_2)

--- a/dbstep/parse_data.py
+++ b/dbstep/parse_data.py
@@ -16,16 +16,6 @@ Currently supporting:
 """
 
 
-def element_id(massno, num=False):
-	"""Return element id number"""
-	try:
-		if num:
-			return periodic_table.index(massno)
-		else: return periodic_table[massno]
-	except IndexError:
-		return "XX"
-
-
 def read_input(molecule, ext, options):
 	"""Chooses a Parser based on input molecule format.
 

--- a/dbstep/parse_data.py
+++ b/dbstep/parse_data.py
@@ -26,8 +26,35 @@ def element_id(massno, num=False):
 		return "XX"
 
 
+def read_input(molecule, ext, options):
+	"""Chooses a Parser based on input molecule format.
+
+	Args:
+		molecule (str or mol object): path to file if molecule represented as one, or RDKit mol object
+		ext (str): file extension used
+		options (dict): options for DBSTEP program
+
+	Returns:
+		DataParser object with parsed molecule data to be used by the rest of the program
+	"""
+	if ext == '.cube':
+		options.surface = 'density'
+		mol = CubeParser(molecule, "cube")
+	else:
+		if ext in [".xyz", '.com', '.gjf']:
+			mol = XYZParser(molecule, ext[1:], options.noH, options.spec_atom_1, options.spec_atom_2)
+		elif ext == 'rdkit':
+			mol = RDKitParser(molecule, options.noH, options.spec_atom_1, options.spec_atom_2)
+		else:
+			mol = cclibParser(molecule, ext[1:], options.noH, options.spec_atom_1, options.spec_atom_2)
+		if options.noH:
+			options.spec_atom_1 = mol.spec_atom_1
+			options.spec_atom_2 = mol.spec_atom_2
+	return mol
+
+
 class DataParser(ABC):
-	""" Abstract base class made to be inherited by parsers for different molecule formats.
+	"""Abstract base class made to be inherited by parsers for different molecule formats.
 
 	Attributes:
 		FORMAT (str): format of the input molecule
@@ -87,7 +114,7 @@ class DataParser(ABC):
 
 
 class CubeParser(DataParser):
-	""" Read data from cube file, obtian XYZ Cartesians, dimensions, and volumetric data """
+	"""Read data from cube file, obtian XYZ Cartesians, dimensions, and volumetric data."""
 
 	def __init__(self, file, input_format):
 		super().__init__(input_format)
@@ -198,8 +225,7 @@ class cclibParser(DataParser):
 
 
 class RDKitParser(DataParser):
-	"""
-	Extract coordinates and atom types from rdkit mol object
+	"""Extract coordinates and atom types from rdkit mol object
 	
 	Attributes:
 		ATOMTYPES (numpy array): List of elements present in molecular file


### PR DESCRIPTION
This PR reorganizes parse_data.py by creating an abstract base class called DataParser which does the generic work for each parser. All of the classes named in the format GetFileType were renamed to FileTypeParser and made to inherit from DataParser. This has reduced code duplication and clearly outlines what is going on in an abstract parser, while letting the individual parsers handle the specifics. 