### PR TITLE
Fixed _get_spec_atoms and implemented first pytest

### DIFF
--- a/dbstep/Dbstep.py
+++ b/dbstep/Dbstep.py
@@ -379,27 +379,23 @@ class dbstep:
 		else:
 			try:
 				options.spec_atom_1 = int(options.spec_atom_1)
-			except ValueError:
-				sys.exit(f'{options.spec_atom_1} is not a valid input for atom1. Please enter an integer index.')
+			except Exception as atom1_exception:
+				raise type(atom1_exception)(f'{options.spec_atom_1} is not a valid input for atom1. Please enter an integer index.')
 		# set default for atom 2
 		if not options.spec_atom_2:
 			options.spec_atom_2 = [2]
 		else:
-			try:
-				# check if int was supplied
-				options.spec_atom_2 = [int(options.spec_atom_2)]
-			except ValueError:
-				# check for multiple atoms supplied
+			if isinstance(options.spec_atom_2, str):
 				if ',' in options.spec_atom_2:
-					# list of ints supplied
-					options.spec_atom_2 = [
-						int(s) if s.isdigit()
-						else sys.exit(f'{s} is not a valid input for atom2. Please enter an integer index.')
-						for s in options.spec_atom_2.split(',')]
-				elif isinstance(options.spec_atom_2, list):
-					pass
+					options.spec_atom_2 = options.spec_atom_2.split(',')
 				else:
-					sys.exit(
+					options.spec_atom_2 = [options.spec_atom_2]
+			elif isinstance(options.spec_atom_2, int):
+				options.spec_atom_2 = [options.spec_atom_2]
+			try:
+				options.spec_atom_2 = [int(atom) for atom in options.spec_atom_2]
+			except Exception as atom2_error:
+				raise type(atom2_error)(
 						f'{options.spec_atom_2} is not a valid input for atom2. Valid inputs are: \n'
 						f'\tAn int, comma separated ints, or a python list of ints')
 

--- a/tests/test_dbstep.py
+++ b/tests/test_dbstep.py
@@ -1,0 +1,37 @@
+import pytest
+
+from dbstep import Dbstep
+
+
+class DbstepShell:
+	"""A reference to the dbstep class so its helper methods can be accessed without running its __init__"""
+	def __init__(self):
+		self.__class__ = Dbstep.dbstep
+
+
+class TestDbstep:
+	"""Class which contains tests for the dbstep class."""
+
+	@pytest.mark.parametrize("input_atom_1, input_atom_2, expected_atom_1, expected_atom_2", [
+		(None, None, 1, [2]),
+		(1, "4,6,1,4", 1, [4, 6, 1, 4]),
+		(3, [3, 4, "5"], 3, [3, 4, 5])
+	])
+	def test_get_spec_atoms(self, input_atom_1, input_atom_2, expected_atom_1, expected_atom_2):
+		options = Dbstep.set_options({'atom1': input_atom_1, 'atom2': input_atom_2})
+		db = DbstepShell()
+		db._get_spec_atoms(options)
+		assert options.spec_atom_1 == expected_atom_1
+		assert options.spec_atom_2 == expected_atom_2
+
+	@pytest.mark.parametrize("input_atom_1, input_atom_2, expected_exception", [
+		(1, "aa", ValueError),
+		("aa", [1], ValueError),
+		(3, [1, 3, "4a"], ValueError),
+		(3, [3, 4, [1, 2, 3]], TypeError),
+	])
+	def test_get_spec_atoms_exception(self, input_atom_1, input_atom_2, expected_exception):
+		options = Dbstep.set_options({'atom1': input_atom_1, 'atom2': input_atom_2})
+		db = DbstepShell()
+		with pytest.raises(expected_exception):
+			db._get_spec_atoms(options)


### PR DESCRIPTION
My original implementation of _get_spec_atoms broke when taking in python lists for spec_atom_2, now its fixed and tested. test_dbstep.py the first of many test files that will exist in the future (about one for each module of DBSTEP ideally).

Currently, I'm thinking a mixture of test classes and fixtures will be a good way to go about testing this project. test_dbtstep.py shows an example of the way I'm thinking test classes will generally look.